### PR TITLE
Fix cloning failure when system is busy.

### DIFF
--- a/cinder/tests/unit/volume/drivers/emc/vnx/test_client.py
+++ b/cinder/tests/unit/volume/drivers/emc/vnx/test_client.py
@@ -144,26 +144,31 @@ class TestClient(test.TestCase):
                           dst_id=5)
         lun.migrate.assert_called_with(5, storops.VNXMigrationRate.HIGH)
 
+    @utils.patch_sleep
     @res_mock.patch_client
-    def test_verify_migration(self, client, mocked):
+    def test_verify_migration(self, client, mocked, sleep_mock):
         r = client.verify_migration(1, 2, 'test_wwn')
         self.assertTrue(r)
 
+    @utils.patch_sleep
     @res_mock.patch_client
-    def test_verify_migration_false(self, client, mocked):
+    def test_verify_migration_false(self, client, mocked, sleep_mock):
         r = client.verify_migration(1, 2, 'fake_wwn')
         self.assertFalse(r)
 
+    @utils.patch_sleep
     @res_mock.patch_client
-    def test_cleanup_migration(self, client, mocked):
+    def test_cleanup_migration(self, client, mocked, sleep_mock):
         client.cleanup_migration(1, 2)
 
     @res_mock.patch_client
     def test_cleanup_migration_not_migrating(self, client, mocked):
         client.cleanup_migration(1, 2)
 
+    @utils.patch_sleep
     @res_mock.patch_client
-    def test_cleanup_migration_cancel_failed(self, client, mocked):
+    def test_cleanup_migration_cancel_failed(self, client, mocked,
+                                             sleep_mock):
         client.cleanup_migration(1, 2)
 
     @res_mock.patch_client

--- a/cinder/volume/drivers/emc/vnx/client.py
+++ b/cinder/volume/drivers/emc/vnx/client.py
@@ -16,6 +16,8 @@ from oslo_log import log as logging
 from oslo_utils import excutils
 from oslo_utils import importutils
 
+import time
+
 storops = importutils.try_import('storops')
 if storops:
     from storops import exception as storops_ex
@@ -221,7 +223,8 @@ class Client(object):
         :returns Boolean: True or False
         """
         src_lun = self.vnx.get_lun(lun_id=src_id)
-
+        # Sleep 30 seconds to make sure the session starts On the VNX.
+        time.sleep(30)
         utils.wait_until(condition=self.session_finished,
                          interval=common.INTERVAL_30_SEC,
                          src_lun=src_lun)

--- a/cinder/volume/drivers/emc/vnx/driver.py
+++ b/cinder/volume/drivers/emc/vnx/driver.py
@@ -80,9 +80,10 @@ class EMCVNXDriver(driver.TransferVD,
                 image cache volume
         8.1.3 - Cherry pick `wrong size of volume from image cache` fix from
                 Pike, https://review.openstack.org/#/c/476402/
+        8.1.4 - Fix occasional failure for cloning volume
     """
 
-    VERSION = '08.01.03'
+    VERSION = '08.01.04'
     VENDOR = 'Dell EMC'
     # ThirdPartySystems wiki page
     CI_WIKI_NAME = "EMC_VNX_CI"


### PR DESCRIPTION
In newton, the 30s wait was removed due to refactor, in this case,
If the session hasn't started in the VNX, the driver would perform
unexpected rollback for the migration.

Adding a wait will make sure the session is started on the VNX thus
cloning can succeed.